### PR TITLE
Prevent adding fragments twice.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ captures/
 # Keystore files
 # Uncomment the following line if you do not want to check your keystore files in.
 #*.jks
+*.keystore
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild

--- a/app/src/main/java/hpsaturn/pollutionreporter/MainActivity.java
+++ b/app/src/main/java/hpsaturn/pollutionreporter/MainActivity.java
@@ -266,26 +266,31 @@ public class MainActivity extends BaseActivity implements
 
     private void addChartFragment() {
         if (chartFragment == null) chartFragment = ChartFragment.newInstance();
+        if (chartFragment.isAdded()) return;
         addFragment(chartFragment, ChartFragment.TAG, false);
     }
 
     private void addScanFragment() {
         if (scanFragment == null) scanFragment = ScanFragment.newInstance();
+        if (scanFragment.isAdded()) return;
         addFragment(scanFragment, ScanFragment.TAG, false);
     }
 
     private void addMapFragment() {
         if (mapFragment == null) mapFragment = MapFragment.newInstance();
+        if (mapFragment.isAdded()) return;
         addFragment(mapFragment, MapFragment.TAG, false);
     }
 
     private void addRecordsFragment() {
         if (recordsFragment == null) recordsFragment = RecordsFragment.newInstance();
+        if (recordsFragment.isAdded()) return;
         addFragment(recordsFragment, RecordsFragment.TAG, false);
     }
 
     private void addPostsFragment() {
         if (postsFragment == null) postsFragment = PostsFragment.newInstance();
+        if (postsFragment.isAdded()) return;
         addFragment(postsFragment, PostsFragment.TAG, false);
     }
 


### PR DESCRIPTION
- [x] Prevent adding fragments twice.
- [x] Update `.gitignore` to avoid committing local keystores.

Fixes #13 